### PR TITLE
[CBP-55699] Update schema and doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,6 +39,11 @@ This action requires prior authentication to the container registry, so you must
 | Enables the verified flag to scan only verified secrets.
 The default is `true`.^<<footnote,[1]>>^
 
+| `exclude-paths`
+| String
+| No
+| Comma-separated list of paths to exclude from the scan.
+
 |=== 
 
 [#footnote]
@@ -100,6 +105,19 @@ The returned secrets are not verified and might include false positives.
           image-tag: ${{ vars.IMAGE_TAG }}
           threshold-very-high: 3
           only-verified: false
+----
+
+In the following example, `exclude-paths` is used to skip specific paths during the scan.
+
+[source,yaml]
+----
+
+      - name: Run TruffleHog container scan with excluded paths
+        uses: cloudbees-io/trufflehog-secret-scan-container@v1
+        with:
+          image-location: ${{ vars.IMAGE_LOCATION }}
+          image-tag: ${{ vars.IMAGE_TAG }}
+          exclude-paths: vendor,/etc/secrets
 ----
 
 == License

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: false
     default: 'true'
     description: 'Enable verified flag to scan only verified secrets.'
+  exclude-paths:
+    required: false
+    default: ''
+    description: 'Comma-separated list of paths to exclude from the scan.'
   threshold-very-high:
     required: false
     default: 999
@@ -55,7 +59,7 @@ runs:
       uses: docker://public.ecr.aws/l7o7z1g8/actions/trufflehog-secret-actions:main-d06d5788ceb7fb8d171973d53f500a4a47f4516b
       shell: sh
       env:
-        CONFIG_JSON: '{"metaInfo":{"imageLocation":"${{ inputs.image-location }}","imageTag":"${{ inputs.image-tag }}","onlyVerified":${{ inputs.only-verified }},"toolName":"trufflehogcontainer"},"orchestratorInfo":{"assetType":"BINARY","assetIdentifier":"${{ inputs.image-location }}","profileIdentifier":"${{ inputs.image-tag }}"},"metaInformation":{"actor":"NA","commit_id":"NA","tenent_info":"NA","scanner_type":"Container"}}' 
+        CONFIG_JSON: '{"metaInfo":{"imageLocation":"${{ inputs.image-location }}","imageTag":"${{ inputs.image-tag }}","onlyVerified":${{ inputs.only-verified }},"excludePaths":"${{ inputs.exclude-paths }}","toolName":"trufflehogcontainer"},"orchestratorInfo":{"assetType":"BINARY","assetIdentifier":"${{ inputs.image-location }}","profileIdentifier":"${{ inputs.image-tag }}"},"metaInformation":{"actor":"NA","commit_id":"NA","tenent_info":"NA","scanner_type":"Container"}}' 
         THRESHOLD_JSON: '{"veryHigh":${{ inputs.threshold-very-high }},"high":${{ inputs.threshold-high }},"medium":${{ inputs.threshold-medium }},"low":${{ inputs.threshold-low }}}'
         RUN_ID: ${{ cloudbees.run_id }}
         STEP_ID: ${{ step.internal.id }}


### PR DESCRIPTION
Applied changes from [calculi-corp/trufflehog-secret-actions#54](https://github.com/calculi-corp/trufflehog-secret-actions/pull/54) to this container action wrapper.

The upstream PR added support for the `--exclude-paths` TruffleHog flag in the IMAGE scan type. When `excludePaths` is provided in the scan configuration, the Go binary passes it to TruffleHog as a comma-separated list of paths to exclude from the scan.
