### PR TITLE
CBP-43509 - Fixing exclude-paths behavior

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,6 +108,8 @@ The returned secrets are not verified and might include false positives.
 ----
 
 In the following example, `exclude-paths` is used to skip specific paths during the scan.
+Paths are matched as regexes against file paths inside the image.
+Multiple paths can be provided as a comma-separated list.
 
 [source,yaml]
 ----
@@ -118,6 +120,19 @@ In the following example, `exclude-paths` is used to skip specific paths during 
           image-location: ${{ vars.IMAGE_LOCATION }}
           image-tag: ${{ vars.IMAGE_TAG }}
           exclude-paths: vendor,/etc/secrets
+----
+
+In the following example, a specific file is excluded to suppress a known false positive in a JVM native library.
+
+[source,yaml]
+----
+
+      - name: Run TruffleHog container scan excluding JVM native libs
+        uses: cloudbees-io/trufflehog-secret-scan-container@v1
+        with:
+          image-location: ${{ vars.IMAGE_LOCATION }}
+          image-tag: ${{ vars.IMAGE_TAG }}
+          exclude-paths: /usr/lib/jvm/java-21-openjdk-21.0.12.0.8-1.2.el9.x86_64/lib/server/libjvm.so
 ----
 
 == License

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,15 @@ runs:
         set -x
         echo "RUN ID: ${{ cloudbees.run_id }}"
         echo "Job ID: ${{ job.id }}"
-        echo "Step ID: ${{ step.internal.id }}"              
+        echo "Step ID: ${{ step.internal.id }}"
         cd /app
+        # trufflehog --exclude-paths expects a file with newline-separated regexes,
+        # not a path string. Write the comma-separated excludePaths to a temp file
+        # and replace the excludePaths value in CONFIG_JSON with the file path.
+        EXCLUDE_PATHS_FILE=""
+        if [ -n "${{ inputs.exclude-paths }}" ]; then
+          EXCLUDE_PATHS_FILE=$(mktemp /tmp/trufflehog-exclude-XXXXXX.txt)
+          echo "${{ inputs.exclude-paths }}" | tr ',' '\n' > "${EXCLUDE_PATHS_FILE}"
+          CONFIG_JSON=$(echo "${CONFIG_JSON}" | sed "s|\"excludePaths\":\"[^\"]*\"|\"excludePaths\":\"${EXCLUDE_PATHS_FILE}\"|")
+        fi
         ./trufflehog_secret_scan_app scan -t 'IMAGE' -c "${CONFIG_JSON}" -r "${THRESHOLD_JSON}"


### PR DESCRIPTION
## Summary

As shown in Keycloak builds throwing false positives and unable to exclude a core jvm executable, this PR attempts to fix the exclude-paths behavior to properly exclude as needed.

## Root Cause

TruffleHog's `--exclude-paths` flag expects a **path to a file** containing newline-separated regexes — not a literal path string. The action was passing `inputs.exclude-paths` directly as the value in `CONFIG_JSON`, so TruffleHog interpreted it as a file path on the scanner container. Since no such file exists there, the exclusion was silently ignored and findings in excluded paths were still reported.

## Fix

In the `run:` block, before invoking the scanner binary, write the comma-separated `exclude-paths` values to a temp file and substitute the file path into `CONFIG_JSON`:

```sh
if [ -n "${{ inputs.exclude-paths }}" ]; then
  EXCLUDE_PATHS_FILE=$(mktemp /tmp/trufflehog-exclude-XXXXXX.txt)
  echo "${{ inputs.exclude-paths }}" | tr ',' '\n' > "${EXCLUDE_PATHS_FILE}"
  CONFIG_JSON=$(echo "${CONFIG_JSON}" | sed "s|\"excludePaths\":\"[^\"]*\"|\"excludePaths\":\"${EXCLUDE_PATHS_FILE}\"|")
fi
```

The README is also updated to clarify that paths are matched as regexes and to add an example of excluding a specific file.

## Test plan
- [ ] Verify that a build with a known false positive in a JVM native library no longer fails when the path is added to `exclude-paths`
- [ ] Verify that a build with a real secret still fails as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)