### PR TITLE
[CBP-55699] Revert pull request #26

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,6 @@ The returned secrets are not verified and might include false positives.
 ----
 
 In the following example, `exclude-paths` is used to skip specific paths during the scan.
-Paths are matched as regexes against file paths inside the image.
-Multiple paths can be provided as a comma-separated list.
 
 [source,yaml]
 ----
@@ -120,19 +118,6 @@ Multiple paths can be provided as a comma-separated list.
           image-location: ${{ vars.IMAGE_LOCATION }}
           image-tag: ${{ vars.IMAGE_TAG }}
           exclude-paths: vendor,/etc/secrets
-----
-
-In the following example, a specific file is excluded to suppress a known false positive in a JVM native library.
-
-[source,yaml]
-----
-
-      - name: Run TruffleHog container scan excluding JVM native libs
-        uses: cloudbees-io/trufflehog-secret-scan-container@v1
-        with:
-          image-location: ${{ vars.IMAGE_LOCATION }}
-          image-tag: ${{ vars.IMAGE_TAG }}
-          exclude-paths: /usr/lib/jvm/java-21-openjdk-21.0.12.0.8-1.2.el9.x86_64/lib/server/libjvm.so
 ----
 
 == License

--- a/action.yml
+++ b/action.yml
@@ -70,15 +70,6 @@ runs:
         set -x
         echo "RUN ID: ${{ cloudbees.run_id }}"
         echo "Job ID: ${{ job.id }}"
-        echo "Step ID: ${{ step.internal.id }}"
+        echo "Step ID: ${{ step.internal.id }}"              
         cd /app
-        # trufflehog --exclude-paths expects a file with newline-separated regexes,
-        # not a path string. Write the comma-separated excludePaths to a temp file
-        # and replace the excludePaths value in CONFIG_JSON with the file path.
-        EXCLUDE_PATHS_FILE=""
-        if [ -n "${{ inputs.exclude-paths }}" ]; then
-          EXCLUDE_PATHS_FILE=$(mktemp /tmp/trufflehog-exclude-XXXXXX.txt)
-          echo "${{ inputs.exclude-paths }}" | tr ',' '\n' > "${EXCLUDE_PATHS_FILE}"
-          CONFIG_JSON=$(echo "${CONFIG_JSON}" | sed "s|\"excludePaths\":\"[^\"]*\"|\"excludePaths\":\"${EXCLUDE_PATHS_FILE}\"|")
-        fi
         ./trufflehog_secret_scan_app scan -t 'IMAGE' -c "${CONFIG_JSON}" -r "${THRESHOLD_JSON}"


### PR DESCRIPTION
Reverts https://github.com/cloudbees-io/trufflehog-secret-scan-container/pull/26.

We needs to upgrade TruffleHog CLI from our actions to use `--exclude-paths`.

https://cloudbees.slack.com/archives/CLVUC7KHQ/p1786606129611549?thread_ts=1786541106.717529&cid=CLVUC7KHQ